### PR TITLE
Fix notifyChange() bug when called on same property from different po…

### DIFF
--- a/src/utils/Observable.js
+++ b/src/utils/Observable.js
@@ -89,35 +89,47 @@ class Observable {
     /**
      * 
      * @param {*} key 
+     * @param {*} observerKey
      * @param {observer} observer function(value, key, observable)
      */
-    observe (key, observer) {
+    observe (key, observer, observerKey = null) {
         this.defineProperty(key)
-        this.#observers[key][observer] = observer
+        if (observerKey == null) {
+            this.#observers[key][observer] = observer;
+        } else {
+            this.#observers[key][observerKey] = observer;
+        }
     }
 
     /**
      * 
      * @param {*} key 
+     * @param {*} observerKey
      * @param {observer} observer function(value, key, observable)
      */
-    unobserve (key, observer) {
-        if (key in this.#observers)
-            delete this.#observers[key][observer]
+    unobserve (key, observer, observerKey = null) {
+        if (key in this.#observers){
+            if (observerKey == null) {
+                delete this.#observers[key][observer];
+            } else {
+                delete this.#observers[key][observerKey];
+            }
+        }
     }
 
     /**
      * 
      * @param {*} key
+     * @param {*} observerKey
      * @returns {Promise} Promise that resolves when observed value changes
      */
-    async notifyChange (key) {
+    async notifyChange (key, observerKey = null) {
         return new Promise( res => {
-            var tmpObs = (value, key) => {
-                this.unobserve(key, tmpObs)
+            var tmpObs = (value, key, observerKey) => {
+                this.unobserve(key, tmpObs, observerKey)
                 res(value)
             }
-            this.observe(key, tmpObs)
+            this.observe(key, tmpObs, observerKey)
         })
     }
 


### PR DESCRIPTION
As discovered and explained by @Samaretas the bug on notifyChange() we discussed by mail is due to the fact that the observer function itself is used as a key in the dictionary of the observers. 
Because of this every time a notifyChange() is called on an already observed property the observer function is overwritten. 

The bug can be fixed by adding a parameter which allow to specify a key for the observer. 
The commit is retro-compatible with previous code since it allows not passing the `observerKey` parameter.