### PR TITLE
Fix predicate `not` not generated for PDDL preconditions

### DIFF
--- a/src/pddl/PddlDomain.js
+++ b/src/pddl/PddlDomain.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 
-
+const padding = ' '.repeat(4)
 
 class PddlDomain {
     
@@ -44,21 +44,27 @@ class PddlDomain {
                 return `
         (:action ${actionClass.name}
             :parameters (${parameters.map( p => '?'+p ).join(' ')})
-            :precondition (and ${precondition.map( p => '('+p[0]+' ' + p.slice(1).map( v => '?'+v ).join(' ') + ')').join(' ')} )
+            :precondition (and
+            ${PddlDomain.mapTokens(precondition)}
+            )
             :effect (and
-                ${effect.map( p => {
-                    let not = p[0].split(' ')[0]=='not'
-                    let predicate = (not ? p[0].split(' ')[1] : p[0])
-                    let args = p.slice(1).map( v => '?'+v ).join(' ')
-                    if (not)
-                        return '(not (' + predicate + ' ' + args + '))'
-                    return '(' + predicate + ' ' + args + ')'
-                }).join('\n\t\t\t')}
+            ${PddlDomain.mapTokens(effect)}
             )
         )`
             }
         
         }
+    }
+
+    static mapTokens(tokens) {
+        return tokens.map( p => {
+            let not = p[0].split(' ')[0]=='not'
+            let predicate = (not ? p[0].split(' ')[1] : p[0])
+            let args = p.slice(1).map( v => '?'+v ).join(' ')
+            if (not)
+                return `${padding}(not (${predicate} ${args}))`
+            return `${padding}(${predicate} ${args})`
+        }).join('\n' + padding.repeat(3))
     }
 
     saveToFile () {
@@ -84,9 +90,9 @@ class PddlDomain {
 (define (domain ${this.name})
     (:requirements :strips)
     (:predicates
-        ${this.predicates.map( p => p.toPddlString()).join('\n\t\t')}              
+        ${this.predicates.map( p => p.toPddlString()).join('\n' + padding.repeat(2))}              
     )
-    ${this.actions.map( a => a.toPddlString()).join('\n\t\t') }
+    ${this.actions.map( a => a.toPddlString()).join('\n' + padding.repeat(2)) }
 )`
     }
 


### PR DESCRIPTION
Before:

```pddl
        (:action Move
            :parameters (?from ?to)
            :precondition (and (on ?from) (not on ?to) (link ?from ?to) )
            :effect (and
                (not (on ?from))
			(on ?to)
            )
        )
```

Note that `(not on ?to)` in the precondition is not correct for PDDL standard.

After:
```pddl
        (:action Move
            :parameters (?from ?to)
            :precondition (and 
                (on ?from)
                (not (on ?to))
                (link ?from ?to)
            )
            :effect (and
                (not (on ?from))
                (on ?to)
            )
        )
```

Also fix use of consisent padding style (spaces vs. tabs)