### PR TITLE
Adding support for non parameterized predicates and negative preconditions

### DIFF
--- a/src/pddl/PddlDomain.js
+++ b/src/pddl/PddlDomain.js
@@ -88,7 +88,7 @@ class PddlDomain {
         return `\
 ;; domain file: domain-${this.name}.pddl
 (define (domain ${this.name})
-    (:requirements :strips)
+    (:requirements :strips :negative-preconditions)
     (:predicates
         ${this.predicates.map( p => p.toPddlString()).join('\n' + padding.repeat(2))}              
     )

--- a/src/pddl/PddlDomain.js
+++ b/src/pddl/PddlDomain.js
@@ -10,12 +10,12 @@ class PddlDomain {
         this.actions = actions
     }
 
-    addPredicate (predicate) { // predicate = ['light-on', 'l']
+    addPredicate (predicate, parameters = []) { // predicate = ['light-on', 'l']
         if ( this.predicates.find( (e) => e[0]==predicate[0]) )
             return false
         this.predicates.push(predicate)
         predicate.toPddlString = function () {
-            return '('+predicate[0]+' ' + predicate.slice(1).map( v => '?'+v ).join(' ') + ')'
+            return '('+predicate[0]+' ' + predicate.slice(1).map( v => (parameters.includes(v) ? "?" + v : v)).join(' ') + ')'
         }
         return predicate
     }
@@ -29,14 +29,14 @@ class PddlDomain {
                 let not = p[0].split(' ')[0]=='not'
                 let predicate = (not ? p[0].split(' ')[1] : p[0])
                 let args = p.slice(1)
-                this.addPredicate([predicate, ...args])
+                this.addPredicate([predicate, ...args], parameters)
             }
 
             for ( let p of effect ) {
                 let not = p[0].split(' ')[0]=='not'
                 let predicate = (not ? p[0].split(' ')[1] : p[0])
                 let args = p.slice(1)
-                this.addPredicate([predicate, ...args])
+                this.addPredicate([predicate, ...args], parameters)
             }
 
             this.actions.push(actionClass)
@@ -45,10 +45,10 @@ class PddlDomain {
         (:action ${actionClass.name}
             :parameters (${parameters.map( p => '?'+p ).join(' ')})
             :precondition (and
-            ${PddlDomain.mapTokens(precondition)}
+            ${PddlDomain.mapTokens(precondition, parameters)}
             )
             :effect (and
-            ${PddlDomain.mapTokens(effect)}
+            ${PddlDomain.mapTokens(effect, parameters)}
             )
         )`
             }
@@ -56,11 +56,11 @@ class PddlDomain {
         }
     }
 
-    static mapTokens(tokens) {
+    static mapTokens(tokens, parameters = []) {
         return tokens.map( p => {
             let not = p[0].split(' ')[0]=='not'
             let predicate = (not ? p[0].split(' ')[1] : p[0])
-            let args = p.slice(1).map( v => '?'+v ).join(' ')
+            let args = p.slice(1).map( v => (parameters.includes(v) ? "?" + v : v)).join(' ')
             if (not)
                 return `${padding}(not (${predicate} ${args}))`
             return `${padding}(${predicate} ${args})`

--- a/src/pddl/actions/pddlActionIntention.js
+++ b/src/pddl/actions/pddlActionIntention.js
@@ -63,8 +63,10 @@ class pddlActionIntention extends Intention {
             let possibly_negated_predicate = literal[0]
             let vars = literal.slice(1)
             let grounded = possibly_negated_predicate
-            for (let v of vars)
-                grounded = grounded + ' ' + parametersMap[v]
+            for (let v of vars) {
+                grounded += " ";
+                grounded += parametersMap[v] ? parametersMap[v] : v;
+            }
             return grounded
         })
     }


### PR DESCRIPTION
### What is this
This will add support for non parameterized predicates in pddl meaning that you can hardcode a value in a predicate, useful in preconditions and effects of actions for example.

### How it works
Predicates are in the form of: 
`(<predicate_name> <argument_1> ... <argument_n>) `

For example:
`(in_room ?r)`

Where `?` is used to mark the argument as a parameter. 
By removing the `?`, the argument becomes an hardcoded value. For example:
`(in_room kitchen)`

Commit 97aacd8caddfb7afaedbab2b12d41c7745024cb6 introduce this feature by checking if the argument is present in the parameters list and adding the `?` accordingly, when creating the predicate string.

Commit 4403ad94b866efe7abeb80df00f0c531733ed9cf simply adds support for negative  preconditions in pddl.

